### PR TITLE
Use correct repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "http://github.com/npm/npm.git"
+    "url": "olivierkaisin/node-mysql-on-the-rocks"
   }
 }


### PR DESCRIPTION
This fixes the issue that this package's page on NPM links to the [npm/npm](https://github.com/npm/npm) repo and its issues and pull requests.
